### PR TITLE
Fixed reference to TRACESWO

### DIFF
--- a/src/bmp-from-bluepill.md
+++ b/src/bmp-from-bluepill.md
@@ -178,8 +178,10 @@ Pill:
 | B3                | JTDO                |                  |
 | B4                | JNTRST              | R                |
 | B6                | UART1 TX            |                  |
-| B7                | UART1 RX            | B3               |
-| A3                | UART2 RX (TRACESWO) |                  |
+| B7                | UART1 RX            | TRACESWO (B3)    |
+
+If you're using an official Black Magic Probe, UART1 RX/TX are found
+on the 4 pin UART conenctor.
 
 ![BMP wiring](./assets/bmp-wiring.jpg)
 


### PR DESCRIPTION
The wiring section incorrectly labelled `UART2 RX` as `TRACESWO`.

This commit moves the `TRACESWO` label over to the Blue Pill Target
column B3 pin, and removes the otherwise unused reference to
`UART2 Rx`.

It also adds a comment about `UART1 RX/TX` being on the UART connector
on the real Black Magic Probe.